### PR TITLE
Throw ArgumentException when bad country code is passed into LoadLocationData();

### DIFF
--- a/src/CountryData/CountryLoader.cs
+++ b/src/CountryData/CountryLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -37,7 +38,7 @@ namespace CountryData
             var entry = archive.Entries.SingleOrDefault(x => x.Name == $"{countryCode}.json.txt");
             if (entry == null)
             {
-                throw new($"Could not find data for '{countryCode}'.");
+                throw new ArgumentException($"Could not find data for '{countryCode}'.");
             }
 
             return ConstructCountry(entry, countryCode);

--- a/src/Tests/CountryLoaderTests.cs
+++ b/src/Tests/CountryLoaderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using CountryData;
 using VerifyXunit;
@@ -11,6 +12,8 @@ public class CountryLoaderTests
     public Task LoadLocationData()
     {
         var country = CountryLoader.LoadLocationData("PW");
+        Assert.Throws<ArgumentException>(() => CountryLoader.LoadLocationData("QQ"));
+
         return Verifier.Verify(country);
     }
 


### PR DESCRIPTION
Issue #327 
LoadLocationData() returned System.Exception. Adding explicit ArgumentException instead. Unit test assertion added.